### PR TITLE
enable v3 app ssh via UI for web: type process

### DIFF
--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -52,31 +52,34 @@ func CheckForV3AvailabilityAndReturnProcessID(appID, baseURL, clientID, token st
 	if resp.StatusCode == http.StatusNotFound {
 		return appID, nil
 	}
-	if resp.StatusCode == http.StatusOK {
-    	processRequest, err := prepareRequest(baseURL, clientID, token, fmt.Sprintf("/v3/apps/%s/processes/web", appID))
-		if err != nil {
-			return appID, sendSSHError("failed preparing v3 request: %s", err)
-		}
-		resp, err := apiClient.Do(processRequest)
-		if err != nil {
-			return appID, sendSSHError("failed checking for processes of app_guid %s => '%s': %s", processRequest.URL.Path, appID, err)
-		}
-		defer resp.Body.Close()
-		respBytes, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return appID, sendSSHError("failed reading response for '%s': %s", resp.Request.URL.Path, err)
-		}
-		appWebProcess := &cfresource.Process{}
-		err = appWebProcess.UnmarshalJSON(respBytes)
-		if err != nil {
-			return appID, sendSSHError("failed unmarshaling response: '%s' for app_guid '%s': %s", string(respBytes), appID, err)
-		}
-		if appWebProcess.GUID == "" {
-			return appID, sendSSHError("the processID returned was empty: %s", string(respBytes))
-		}
-		return appWebProcess.GUID, nil
+
+	if resp.StatusCode != http.StatusOK {
+		return appID, err
 	}
-	return appID, err
+
+    processRequest, err := prepareRequest(baseURL, clientID, token, fmt.Sprintf("/v3/apps/%s/processes/web", appID))
+	if err != nil {
+		return appID, sendSSHError("failed preparing v3 request: %s", err)
+	}
+	resp, err = apiClient.Do(processRequest)
+	if err != nil {
+		return appID, sendSSHError("failed checking for processes of app_guid %s => '%s': %s", processRequest.URL.Path, appID, err)
+	}
+	defer resp.Body.Close()
+	respBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return appID, sendSSHError("failed reading response for '%s': %s", resp.Request.URL.Path, err)
+	}
+	appWebProcess := &cfresource.Process{}
+	err = appWebProcess.UnmarshalJSON(respBytes)
+	if err != nil {
+		return appID, sendSSHError("failed unmarshaling response: '%s' for app_guid '%s': %s", string(respBytes), appID, err)
+	}
+	if appWebProcess.GUID == "" {
+		return appID, sendSSHError("the processID returned was empty: %s", string(respBytes))
+	}
+	return appWebProcess.GUID, nil
+
 }
 func (cfAppSsh *CFAppSSH) appSSH(c echo.Context) error {
 	// Need to get info for the endpoint

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -53,8 +53,8 @@ func CheckForV3AvailabilityAndReturnProcessID(appID, baseURL, clientID, token st
 		return appID, nil
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		return appID, err
+	if resp.StatusCode != http.StatusOK || err != nil{
+		return appID, sendSSHError( "received unexpected error: '%w' or status: '%v' ",err, resp.StatusCode )
 	}
 
     processRequest, err := prepareRequest(baseURL, clientID, token, fmt.Sprintf("/v3/apps/%s/processes/web", appID))

--- a/src/jetstream/plugins/cfappssh/app_ssh.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh.go
@@ -10,8 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"time"
-
-	cloudFoundryResource "code.cloudfoundry.org/cli/resources"
+	cfresource "code.cloudfoundry.org/cli/resources"
 	"github.com/cloudfoundry/stratos/src/jetstream/api"
 	"github.com/gorilla/websocket"
 	"github.com/labstack/echo/v4"
@@ -67,7 +66,7 @@ func CheckForV3AvailabilityAndReturnProcessID(appID, baseURL, clientID, token st
 		if err != nil {
 			return appID, sendSSHError("failed reading response for '%s': %s", resp.Request.URL.Path, err)
 		}
-		appWebProcess := &cloudFoundryResource.Process{}
+		appWebProcess := &cfresource.Process{}
 		err = appWebProcess.UnmarshalJSON(respBytes)
 		if err != nil {
 			return appID, sendSSHError("failed unmarshaling response: '%s' for app_guid '%s': %s", string(respBytes), appID, err)

--- a/src/jetstream/plugins/cfappssh/app_ssh_test.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh_test.go
@@ -1,0 +1,81 @@
+package cfappssh_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"github.com/cloudfoundry/stratos/src/jetstream/plugins/cfappssh"
+	"github.com/labstack/echo/v4"
+)
+
+type FakeContext struct {
+	echo.Context
+}
+
+func TestCheckForV3Availability(t *testing.T) {
+	expectedProcessID := "i-am-process-id"
+	appGUID := "some-guid"
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+		appWebProcess := map[string]string{
+			"AppGUID": "one two three",
+			"guid": "i-am-process-id",
+			"Type": "web",
+		}
+		re := regexp.MustCompile("^/v3")
+
+		if re.Match([]byte(r.URL.Path)) && r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.URL.Path == fmt.Sprintf("/v3/apps/%s/processes/web", appGUID) && r.Method == http.MethodGet {
+			body, err := json.Marshal(appWebProcess)
+			if err != nil {
+				t.Error("failed creating response body")
+			}
+			w.WriteHeader(http.StatusOK)
+
+			w.Write(body)
+			return
+		}
+	}))
+	defer testServer.Close()
+
+	apiClient := http.Client{}
+	processID, err := cfappssh.CheckForV3AvailabilityAndReturnProcessID(appGUID, testServer.URL, "","", apiClient)
+	if err != nil {
+		t.Errorf("I didn't expect that: %s",err)
+	}
+	if processID != expectedProcessID {
+		t.Errorf("the value should have changed to %s but was %s", expectedProcessID, appGUID)
+	}
+}
+
+func TestV2InstanceWebProcessSSH(t *testing.T) {
+	expectedProcessID := "some-guid"
+	appGUID := "some-guid"
+	t.Parallel()
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		re := regexp.MustCompile("^/v3")
+
+		if re.Match([]byte(r.URL.Path)) && r.Method == http.MethodHead {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer testServer.Close()
+
+	apiClient := http.Client{}
+	processID, err := cfappssh.CheckForV3AvailabilityAndReturnProcessID(appGUID, testServer.URL, "","", apiClient)
+	if err != nil {
+		t.Errorf("I didn't expect that: %s",err)
+	}
+	if processID != expectedProcessID {
+		t.Errorf("the value should NOT have changed. expected %s but was %s", expectedProcessID, processID)
+	}
+}

--- a/src/jetstream/plugins/cfappssh/app_ssh_test.go
+++ b/src/jetstream/plugins/cfappssh/app_ssh_test.go
@@ -9,22 +9,17 @@ import (
 	"testing"
 
 	"github.com/cloudfoundry/stratos/src/jetstream/plugins/cfappssh"
-	"github.com/labstack/echo/v4"
 )
-
-type FakeContext struct {
-	echo.Context
-}
 
 func TestCheckForV3Availability(t *testing.T) {
 	expectedProcessID := "i-am-process-id"
 	appGUID := "some-guid"
 
-	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		appWebProcess := map[string]string{
 			"AppGUID": "one two three",
-			"guid": "i-am-process-id",
-			"Type": "web",
+			"guid":    "i-am-process-id",
+			"Type":    "web",
 		}
 		re := regexp.MustCompile("^/v3")
 
@@ -48,7 +43,7 @@ func TestCheckForV3Availability(t *testing.T) {
 	apiClient := http.Client{}
 	processID, err := cfappssh.CheckForV3AvailabilityAndReturnProcessID(appGUID, testServer.URL, "","", apiClient)
 	if err != nil {
-		t.Errorf("I didn't expect that: %s",err)
+		t.Errorf("I didn't expect that: %s", err)
 	}
 	if processID != expectedProcessID {
 		t.Errorf("the value should have changed to %s but was %s", expectedProcessID, appGUID)
@@ -62,6 +57,7 @@ func TestV2InstanceWebProcessSSH(t *testing.T) {
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		re := regexp.MustCompile("^/v3")
+		t.Log("path", r.URL.Path, "method", r.Method)
 
 		if re.Match([]byte(r.URL.Path)) && r.Method == http.MethodHead {
 			w.WriteHeader(http.StatusNotFound)
@@ -73,7 +69,7 @@ func TestV2InstanceWebProcessSSH(t *testing.T) {
 	apiClient := http.Client{}
 	processID, err := cfappssh.CheckForV3AvailabilityAndReturnProcessID(appGUID, testServer.URL, "","", apiClient)
 	if err != nil {
-		t.Errorf("I didn't expect that: %s",err)
+		t.Errorf("I didn't expect that: %s", err)
 	}
 	if processID != expectedProcessID {
 		t.Errorf("the value should NOT have changed. expected %s but was %s", expectedProcessID, processID)


### PR DESCRIPTION
currently the UI fails establishing an ssh connection to apps that rely on cc v3 functionality. Some basic apps ( e.g. `cf push test -b staticfile_buildpack` seems to produce an app that the UI can still ssh into ) still work but anything that relies on v3 functionality ( e.g. multi process apps or `cf push --strategy rolling` ) will fail.

The default type for a process of a pushed app is `web`. This commit enables using the UI to ssh to the default web process of V3 apps. It left out adding support for all other process types since the UI misses the feature to select nested processes. It only displays the `instances` that an app has running but none of the nested elements of V3 apps.